### PR TITLE
refactor: generic logo sizing support

### DIFF
--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -238,6 +238,7 @@ type Config = {
 		rest_api_base_url: string;
 		webui_custom?: {
 			logo?: string;
+			logoMaxHeight?: string;
 			bgImageAuth?: string;
 			bgImageAuthLight?: string;
 		};

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -28,7 +28,9 @@
 
 	let ldapUsername = '';
 
-	let brandingLogo = $config?.private_ai?.webui_custom ? JSON.parse($config?.private_ai?.webui_custom)?.logo : '';
+	const webuiCustom = $config?.private_ai?.webui_custom ? JSON.parse($config?.private_ai?.webui_custom) : {};
+	let brandingLogo = webuiCustom?.logo || '';
+	let logoMaxHeight = webuiCustom?.logoMaxHeight || '25px';
 	let bgImageAuth = '';
 
 	const querystringValue = (key) => {
@@ -251,7 +253,7 @@
 										src={brandingLogo}
 										alt="Logo"
 										class="mx-auto mb-8"
-                    style="max-height:25px;"
+										style="max-height:{logoMaxHeight};"
 									/>              
 								{/if}                
 								<div class=" text-2xl font-medium">


### PR DESCRIPTION
added new parameter, `logoMaxHeight`, to allow UI to set the max logo width.
- backward compatible with existing logos, so we do not have to update NH_WEBUI_CUSTOM with the new parameter

**NH_WEBUI_CUSTOM**
```json
{
   "logo": "https://storage.googleapis.com/nethopper-pai-assets/pw-assets/xxx.svg",
   "logoMaxHeight": "80px"
}
```


